### PR TITLE
Limit mapping fields to count of available CF7 forms

### DIFF
--- a/inc/class.admin.php
+++ b/inc/class.admin.php
@@ -130,7 +130,7 @@ class CF7_Mautic_Admin extends CF7_Mautic {
 		$html .= '<th>'. __( 'Form ID', self::$text_domain ). '<br/>';
 		$html .= __( '( Mautic )', self::$text_domain ). '</th>';
 		$html .= '</thead><tbody>';
-		for ( $i = 0 ; $i < 5; $i++ ) {
+		for ( $i = 0 ; $i < count( $forms ); $i++ ) {
 			$html .= '<tr>';
 			$html .= '<th>'. __( 'Mapping-', self::$text_domain ). $i. '</th>';
 			$html .= '<td>'. $this->_get_cf7_form_select_box ( $forms, $i ). '</td>';


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Issues addressed (#s or URLs) | #14 
| BC breaks? | 
| Deprecations? | 
| Your wordpress.org's username | @felipeelia

[//]: # ( Required: )
#### Description: Currently it's only possible to map 5 forms. This PR makes possible mapping all available forms. 
This PR solves an immediate problem, but IMO, the select boxes aren't the ideal solution. We should have a list of all CF7 forms with a list of input fields, with names as `name='cf7_mautic_settings[form_id][{$post_id}]' ` or something like that. What do you think? If you agree with that I can change the necessary code. The only problem would be backward compatibility, as it would change the current behavior of using a bidimensional array and array_search to find the id of given post_id.

#### Steps to test this PR:
1. Access the configuration page
2. Check the quantity of available forms
3. Add ou remove a form
4. Access the configuration page again
5. Recheck the quantity

As we do have just a 1:1 relation, I think we should make possible to user map all forms.