### PR TITLE
Update class.submit.php - user IP problem  issue [amimoto-ami#2]

### DIFF
--- a/inc/class.submit.php
+++ b/inc/class.submit.php
@@ -154,9 +154,9 @@ class CF7_Mautic_Submit extends CF7_Mautic {
 	 */
 	private function _get_ip() {
 		$ip_list = [
-            'REMOTE_ADDR',
+            'HTTP_X_FORWARDED_FOR',
+			'REMOTE_ADDR',
 			'HTTP_CLIENT_IP',
-			'HTTP_X_FORWARDED_FOR',
 			'HTTP_X_FORWARDED',
 			'HTTP_X_CLUSTER_CLIENT_IP',
 			'HTTP_FORWARDED_FOR',


### PR DESCRIPTION
Solves the user IP problem  issue [amimoto-ami#2]. 

'REMOTE_ADDR' is populated each time but holds the server address. 'HTTP_X_FORWARDED_FOR' holds the client address. 

The foreach loop at line 165 finds the REMOTE_ADDR and the quits the loop therefore 'HTTP_X_FORWARDED_FOR' is never sent. 

This has been tested and is working in production for us. 

Qasim
onewood.co

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Yes
| New feature? | No 
| Issues addressed (#s or URLs) | [amimoto-ami#2]
| BC breaks? | 
| Deprecations? | 
| Your wordpress.org's username |

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:


#### Steps to test this PR:
1. Get current IP address from whatsmyip.com
2. Go to WP installation with CF7-Mautic
3. Submit a new form
4. Check for the location in Mautic to see if it matches the location of the IP in step 1

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. 
2. 

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 